### PR TITLE
Improve logging and error handling

### DIFF
--- a/Zaid/__main__.py
+++ b/Zaid/__main__.py
@@ -11,6 +11,7 @@ from Zaid.plugins.autoleave import leave_from_inactive_call
 
 logging.basicConfig(format='[%(levelname) 5s/%(asctime)s] %(name)s: %(message)s',
                     level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 path = "Zaid/plugins/*.py"
 files = glob.glob(path)
@@ -21,18 +22,18 @@ for name in files:
         load_plugins(plugin_name.replace(".py", ""))
     
 async def start_bot():
-     print("[INFO]: LOADING ASSISTANT DETAILS")
+     logger.info("LOADING ASSISTANT DETAILS")
      botme = await client.get_me()
      botid = telethon.utils.get_peer_id(botme)
-     print(f"[INFO]: ASSISTANT ID {botid}")
+     logger.info("ASSISTANT ID %s", botid)
      await asyncio.create_task(leave_from_inactive_call())
 
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(start_bot())
 
-print("[INFO]: SUCCESSFULLY STARTED BOT!")
-print("[INFO]: VISIT @TheUpdatesChannel")
+logger.info("SUCCESSFULLY STARTED BOT!")
+logger.info("VISIT @TheUpdatesChannel")
 
 if __name__ == "__main__":
     Zaid.run_until_disconnected()

--- a/Zaid/helpers/thumbnail.py
+++ b/Zaid/helpers/thumbnail.py
@@ -134,5 +134,5 @@ async def gen_thumb(videoid):
         background.save(f"cache/{videoid}_{anime}.png")
         return f"cache/{videoid}_{anime}.png"
     except Exception as e:
-        print(e)
+        logging.getLogger(__name__).error("Thumbnail generation error: %s", e)
         return YOUTUBE_IMG_URL

--- a/Zaid/plugins/play.py
+++ b/Zaid/plugins/play.py
@@ -28,6 +28,8 @@ import logging
 import re
 from yt_dlp import YoutubeDL
 
+logger = logging.getLogger(__name__)
+
 fotoplay = "https://telegra.ph/file/b6402152be44d90836339.jpg"
 ngantri = "https://telegra.ph/file/b6402152be44d90836339.jpg"
 from Zaid import call_py, Zaid, client as Client
@@ -65,7 +67,7 @@ def ytsearch(query: str):
         videoid = data["id"]
         return [songname, url, duration, thumbnail, videoid]
     except Exception as e:
-        print(e)
+        logger.error("ytsearch failed for %s: %s", query, e)
         return 0
 
 
@@ -79,11 +81,7 @@ async def has_active_vc(chat_id: int) -> bool:
 
 
 async def ytdl(format: str, query: str, event=None):
-
-
-    Returns:
-        Tuple[int, str]: (1, url) on success, (0, error) on failure.
-    """
+    """Return a direct media URL using yt-dlp."""
 
     def _extract() -> str:
         ydl_opts = {"format": format, "quiet": True}
@@ -94,15 +92,14 @@ async def ytdl(format: str, query: str, event=None):
                 info = info["entries"][0]
             return info["url"]
 
-    loop = asyncio.get_event_loop()
     try:
-        url = await loop.run_in_executor(None, _extract)
+        url = await asyncio.to_thread(_extract)
         return 1, url
     except Exception as e:
-        logging.error("yt-dlp extraction error for %s: %s", query, e)
-
+        logger.error("yt-dlp extraction error for %s: %s", query, e)
         if event:
             await event.reply(f"**ERROR:** `{e}`")
+        return 0, str(e)
 
 
 async def skip_item(chat_id: int, x: int):
@@ -114,7 +111,7 @@ async def skip_item(chat_id: int, x: int):
         chat_queue.pop(x)
         return songname
     except Exception as e:
-        print(e)
+        logger.error("Error skipping item in queue: %s", e)
         return 0
 
 
@@ -123,6 +120,7 @@ async def skip_current_song(chat_id: int):
         return 0
     chat_queue = get_queue(chat_id)
     if len(chat_queue) == 1:
+        logger.info("Voice chat %s ended", chat_id)
         await call_py.leave_group_call(chat_id)
         clear_queue(chat_id)
         active.remove(chat_id)
@@ -150,6 +148,7 @@ async def skip_current_song(chat_id: int):
             chat_id, AudioVideoPiped(url, HighQualityAudio(), hm)
         )
     pop_an_item(chat_id)
+    logger.info("Now playing next song in chat %s", chat_id)
     return [songname, link, type]
 
 
@@ -567,7 +566,7 @@ async def vc_resume(event, perm):
 @call_py.on_stream_end()
 async def stream_end_handler(_, u: Update):
     chat_id = u.chat_id
-    print(chat_id)
+    logger.info("Stream ended in chat %s", chat_id)
     await skip_current_song(chat_id)
 
 

--- a/Zaid/utils.py
+++ b/Zaid/utils.py
@@ -11,4 +11,4 @@ def load_plugins(plugin_name):
     load.logger = logging.getLogger(plugin_name)
     spec.loader.exec_module(load)
     sys.modules["Zaid.plugins." + plugin_name] = load
-    print("Bot has Started " + plugin_name)
+    logging.getLogger(__name__).info("Plugin loaded %s", plugin_name)

--- a/server.py
+++ b/server.py
@@ -1,13 +1,26 @@
 import os
+import logging
 from flask import Flask
 from flask_restful import Resource, Api
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 api = Api(app)
 
-class Greeting (Resource):
+class Greeting(Resource):
     def get(self):
+        logger.info("Greeting endpoint called")
         return "Telethon Music is Up & Running!"
 
 api.add_resource(Greeting, '/')
-app.run(host="0.0.0.0", port=os.environ.get("PORT", 8080))
+
+def main() -> None:
+    port = int(os.environ.get("PORT", 8080))
+    logger.info("Starting server on port %s", port)
+    app.run(host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand server script with logger and a proper main
- add a logger in `play.py` and return proper errors from `ytdl`
- log queue actions and stream end events
- log plugin loads and thumbnail generation errors
- switch prints in the main module to logging

## Testing
- `python -m py_compile server.py Zaid/__main__.py Zaid/utils.py Zaid/plugins/play.py Zaid/helpers/thumbnail.py`

------
https://chatgpt.com/codex/tasks/task_e_68535cfafbe48322888baf4ec7dbd7e5