### PR TITLE
Refactor startup and server logging

### DIFF
--- a/Zaid/__main__.py
+++ b/Zaid/__main__.py
@@ -1,38 +1,42 @@
 import asyncio
-import telethon
-import glob
 from pathlib import Path
-from Zaid.utils import load_plugins
 import logging
-from Zaid import Zaid
-from Zaid import client, ASSISTANT_ID
+import telethon
+
+from Zaid.utils import load_plugins
+from Zaid import Zaid, client
 from Zaid.plugins.autoleave import leave_from_inactive_call
 
 
-logging.basicConfig(format='[%(levelname) 5s/%(asctime)s] %(name)s: %(message)s',
-                    level=logging.INFO)
-
-path = "Zaid/plugins/*.py"
-files = glob.glob(path)
-for name in files:
-    with open(name) as a:
-        patt = Path(a.name)
-        plugin_name = patt.stem
-        load_plugins(plugin_name.replace(".py", ""))
-    
-async def start_bot():
-     print("[INFO]: LOADING ASSISTANT DETAILS")
-     botme = await client.get_me()
-     botid = telethon.utils.get_peer_id(botme)
-     print(f"[INFO]: ASSISTANT ID {botid}")
-     await asyncio.create_task(leave_from_inactive_call())
+logging.basicConfig(
+    format="[%(levelname) 5s/%(asctime)s] %(name)s: %(message)s",
+    level=logging.INFO,
+)
+logger = logging.getLogger(__name__)
 
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(start_bot())
+def load_all_plugins() -> None:
+    """Load every plugin inside the plugins directory."""
+    for path in Path("Zaid/plugins").glob("*.py"):
+        load_plugins(path.stem)
 
-print("[INFO]: SUCCESSFULLY STARTED BOT!")
-print("[INFO]: VISIT @TheUpdatesChannel")
+
+async def start_bot() -> None:
+    logger.info("LOADING ASSISTANT DETAILS")
+    botme = await client.get_me()
+    botid = telethon.utils.get_peer_id(botme)
+    logger.info("ASSISTANT ID %s", botid)
+    await asyncio.create_task(leave_from_inactive_call())
+
+
+def main() -> None:
+    load_all_plugins()
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(start_bot())
+    logger.info("SUCCESSFULLY STARTED BOT!")
+    logger.info("VISIT @TheUpdatesChannel")
+    Zaid.run_until_disconnected()
+
 
 if __name__ == "__main__":
-    Zaid.run_until_disconnected()
+    main()

--- a/Zaid/helpers/thumbnail.py
+++ b/Zaid/helpers/thumbnail.py
@@ -44,7 +44,8 @@ async def gen_thumb(videoid):
         for result in (await results.next())["result"]:
             try:
                 title = result["title"]
-                title = re.sub("\W+", " ", title)
+                # sanitize any non-word characters for PIL text drawing
+                title = re.sub(r"\W+", " ", title)
                 title = title.title()
             except:
                 title = "Unsupported Title"
@@ -134,5 +135,5 @@ async def gen_thumb(videoid):
         background.save(f"cache/{videoid}_{anime}.png")
         return f"cache/{videoid}_{anime}.png"
     except Exception as e:
-        print(e)
+        logging.getLogger(__name__).error("Thumbnail generation error: %s", e)
         return YOUTUBE_IMG_URL

--- a/Zaid/utils.py
+++ b/Zaid/utils.py
@@ -3,12 +3,22 @@ import logging
 import importlib
 from pathlib import Path
 
+
 def load_plugins(plugin_name):
+    """Dynamically load a plugin by name and log the result."""
+    logger = logging.getLogger(__name__)
     path = Path(f"Zaid/plugins/{plugin_name}.py")
-    name = "Zaid.plugins.{}".format(plugin_name)
+    name = f"Zaid.plugins.{plugin_name}"
     spec = importlib.util.spec_from_file_location(name, path)
-    load = importlib.util.module_from_spec(spec)
-    load.logger = logging.getLogger(plugin_name)
-    spec.loader.exec_module(load)
-    sys.modules["Zaid.plugins." + plugin_name] = load
-    print("Bot has Started " + plugin_name)
+    if spec is None:
+        logger.error("Plugin spec not found for %s", plugin_name)
+        return
+    module = importlib.util.module_from_spec(spec)
+    module.logger = logging.getLogger(plugin_name)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        logger.exception("Failed to load plugin %s", plugin_name)
+        return
+    sys.modules[name] = module
+    logger.info("Plugin loaded %s", plugin_name)

--- a/server.py
+++ b/server.py
@@ -1,13 +1,29 @@
 import os
+import logging
 from flask import Flask
 from flask_restful import Resource, Api
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 api = Api(app)
 
-class Greeting (Resource):
+
+class Greeting(Resource):
     def get(self):
+        logger.info("Greeting endpoint called")
         return "Telethon Music is Up & Running!"
 
+
 api.add_resource(Greeting, '/')
-app.run(host="0.0.0.0", port=os.environ.get("PORT", 8080))
+
+
+def main() -> None:
+    port = int(os.environ.get("PORT", 8080))
+    logger.info("Starting server on port %s", port)
+    app.run(host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refactor main module to use a `main()` function and simplified plugin loader
- ensure `load_plugins` logs success or failure with clearer code style
- add spacing and docstrings for `server`

## Testing
- `apt-get update`
- `apt-get install -y curl unzip`
- `curl` download of ffmpeg *(failed: not a zip)*
- `unzip ffmpeg.zip` *(failed: not a zip)*
- `pip install -r requirements.txt`
- `python -m py_compile server.py Zaid/__main__.py Zaid/utils.py Zaid/plugins/play.py Zaid/helpers/thumbnail.py`
- `flake8 Zaid/__main__.py Zaid/utils.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_68535cfafbe48322888baf4ec7dbd7e5